### PR TITLE
Update dependencies to current structures

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up JDK 17 for Sonar-build
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: maven
 
@@ -71,7 +71,7 @@ jobs:
       - name: Set up JDK 17 for snapshot release
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           server-id: sonatype-nexus-snapshots
           server-username: MAVEN_USERNAME

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 21,23 ]
+        version: [ 21,25 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 17,21,23 ]
+        version: [ 21,23 ]
 
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A Quarkus-based JSF web application serving as the **CUI Portal Reference Documentation**. It showcases CUI JSF components, Portal UI features, PrimeFaces integrations, and Bootstrap elements as interactive, browsable documentation pages.
+
+## Build & Development Commands
+
+```bash
+# Build and run tests
+./mvnw verify
+
+# Run locally in dev mode (hot-reload)
+./mvnw quarkus:dev
+
+# Run a single test class
+./mvnw test -Dtest=ConfigDocuBeanTest
+
+# Run a single test method
+./mvnw test -Dtest=ConfigDocuBeanTest#testMethod
+
+# Build without tests
+./mvnw package -DskipTests
+```
+
+CI builds against Java 17, 21, and 23 using `./mvnw verify`.
+
+## Architecture
+
+### Technology Stack
+- **Runtime**: Quarkus with MyFaces (JSF/Faces) via `myfaces-quarkus` extension
+- **UI Framework**: CUI JSF components (`cui-jsf-bootstrap`, `cui-jsf-core-components`) + PrimeFaces (Jakarta classifier)
+- **Portal Framework**: CUI Portal UI (`portal-ui-quarkus-extension`) and Portal Core for configuration, authentication, navigation, templating
+- **CDI**: Jakarta CDI with Quarkus Arc (note: `quarkus.arc.unremovable-types=de.cuioss.portal.**` keeps portal beans)
+- **Build**: Maven with `cui-parent-pom` (provides dependency versions, plugins, profiles)
+- **Lombok**: Enabled with `@LombokGenerated` annotation for coverage exclusion
+
+### Package Structure (`de.cuioss.portal.reference`)
+
+- **`portal/`** — Portal integration layer:
+  - `ReferenceTemplates` — Registers custom Facelets templates (`layout_portal_core.xhtml`, `layout_portal_labeledContainer.xhtml`)
+  - `navigation/ReferenceMenuProvider` — `@SessionScoped` alternative that builds the full navigation menu hierarchy
+  - `navigation/items/` — Individual menu item classes organized by section (bootstrap, cui, external, icon, portal, prime)
+  - `application/ReferenceBundle` — Resource bundle registration
+
+- **`pages/`** — Backing beans for documentation pages:
+  - `components/demo/` — Demo backing beans for individual component showcases (dialogs, lazy loading, data tables, etc.)
+  - `demo/` — General demo beans (address generator, graph demos)
+  - `portal/` — Portal-specific page beans (bundle overview, template descriptors)
+  - Icon overview beans (`CuiIconsOverviewPageBean`, `MimeTypeIconsPageBean`, `PrimeFacesIconsOverviewPageBean`)
+
+### View Layer
+- **Templates**: `src/main/resources/META-INF/templates/reference/` — Facelets layout templates
+- **Pages**: `src/main/resources/META-INF/resources/documentation/` — XHTML pages organized by documentation section (portal, cui_components, icons, demo, external, prime, getting_started)
+- **Config**: `src/main/resources/META-INF/microprofile-config.properties` — Portal navigation, authentication mock, and menu configuration
+
+### Authentication
+Uses `portal-authentication-mock` at runtime — always returns an authenticated user with `Master-Administrator` role. This is a documentation app, not a secured application.
+
+## Conventions
+
+- Backing beans use `@SessionScoped`, `@ViewScoped`, or `@Dependent` CDI scopes with Lombok (`@EqualsAndHashCode`, `@ToString`, `@Getter`)
+- Navigation menu items implement `NavigationMenuItem`/`NavigationMenuItemContainer` from `cui-jsf-api`
+- Portal priorities use `PortalPriorities.PORTAL_MODULE_LEVEL` for `@Priority` annotations
+- Tests extend CUI base test classes (e.g., `BaseModuleConsistencyTest` for CDI wiring consistency)
+- 4-space indent, UTF-8, LF line endings (see `.editorconfig`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@ A Quarkus-based JSF web application serving as the **CUI Portal Reference Docume
 # Build and run tests
 ./mvnw verify
 
+./mvnw clean install -Ppre-commit
+
 # Run locally in dev mode (hot-reload)
 ./mvnw quarkus:dev
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>de.cuioss</groupId>
-        <artifactId>cui-parent-pom</artifactId>
+        <artifactId>cui-java-parent</artifactId>
         <version>1.4.4</version>
         <relativePath/>
     </parent>
@@ -32,11 +32,14 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
+    <maven.compiler.release>21</maven.compiler.release>
         <version.cui.jsf.components>1.0.0</version.cui.jsf.components>
         <version.cui.portal.core>1.4.0</version.cui.portal.core>
         <version.cui.portal.ui>1.0.0-SNAPSHOT</version.cui.portal.ui>
         <version.quarkus>3.32.0</version.quarkus>
-        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
+        <maven.jar.plugin.automatic.module.name>
+            de.cuioss.portal.reference.documentation
+        </maven.jar.plugin.automatic.module.name>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -154,6 +157,7 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+      <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.config</groupId>
@@ -296,64 +300,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${maven.jar.plugin.version}</version>
-                <configuration>
-                    <excludes>
-                        <exclude>**/log4j2.xml</exclude>
-                        <!-- Exclude eclipse workspace files -->
-                        <exclude>**/*.jsfdia</exclude>
-                    </excludes>
-                    <archive>
-                        <index>true</index>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                        <manifestEntries>
-                            <Build-Time>${maven.build.timestamp}</Build-Time>
-                            <Build-User>${user.name}</Build-User>
-                            <Build-Maven>Maven ${maven.version}</Build-Maven>
-                            <Build-Java>${java.version}</Build-Java>
-                            <Build-OS>${os.name}</Build-OS>
-                            <Build-Number>${buildNumber}</Build-Number>
-                        </manifestEntries>
-                    </archive>
-                </configuration>
             </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
-                <plugin>
-                    <groupId>org.eclipse.m2e</groupId>
-                    <artifactId>lifecycle-mapping</artifactId>
-                    <version>1.0.0</version>
-                    <configuration>
-                        <lifecycleMappingMetadata>
-                            <pluginExecutions>
-                                <pluginExecution>
-                                    <pluginExecutionFilter>
-                                        <groupId>
-                                            org.apache.maven.plugins
-                                        </groupId>
-                                        <artifactId>
-                                            maven-antrun-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            [3.1.0,)
-                                        </versionRange>
-                                        <goals>
-                                            <goal>run</goal>
-                                        </goals>
-                                    </pluginExecutionFilter>
-                                    <action>
-                                        <ignore/>
-                                    </action>
-                                </pluginExecution>
-                            </pluginExecutions>
-                        </lifecycleMappingMetadata>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.cuioss</groupId>
         <artifactId>cui-parent-pom</artifactId>
-        <version>0.8.3</version>
+        <version>1.4.4</version>
         <relativePath/>
     </parent>
     <groupId>de.cuioss.portal.quarkus</groupId>
@@ -32,10 +32,11 @@
         <system>GitHub Issues</system>
     </issueManagement>
     <properties>
-        <version.cui.parent>0.8.3</version.cui.parent>
-        <version.cui.jsf.components>1.0.0-SNAPSHOT</version.cui.jsf.components>
-        <version.cui.portal.core>1.0.0</version.cui.portal.core>
+        <version.cui.jsf.components>1.0.0</version.cui.jsf.components>
+        <version.cui.portal.core>1.4.0</version.cui.portal.core>
         <version.cui.portal.ui>1.0.0-SNAPSHOT</version.cui.portal.ui>
+        <version.quarkus>3.32.0</version.quarkus>
+        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -72,6 +73,13 @@
             <dependency>
                 <groupId>de.cuioss</groupId>
                 <artifactId>java-ee-10-bom</artifactId>
+                <version>${version.cui.parent}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>de.cuioss</groupId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${version.cui.parent}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -274,9 +282,21 @@
             <plugin>
                 <groupId>io.quarkus</groupId>
                 <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${version.quarkus}</version>
+                <extensions>true</extensions>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build</goal>
+                            <goal>generate-code</goal>
+                            <goal>generate-code-tests</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
                 <configuration>
                     <excludes>
                         <exclude>**/log4j2.xml</exclude>

--- a/src/main/java/de/cuioss/portal/reference/pages/ConfigDocuBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/ConfigDocuBean.java
@@ -26,6 +26,7 @@ import lombok.Value;
 import org.primefaces.util.IOUtils;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -69,15 +70,17 @@ public class ConfigDocuBean {
                     properties.load(file.openStream());
                     if (properties.containsKey(NAME_KEY)) {
                         String name = properties.getProperty(NAME_KEY);
-                        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Adding properties %s", name);
+                        // cui-rewrite:disable CuiLogRecordPatternRecipe
+                        LOGGER.info("Adding properties %s", name);
                         defaultConfigSources.add(new DefaultConfigSource(file, name, "lang-properties", IOUtils.toString(file.openStream(), StandardCharsets.UTF_8)));
                     }
                 } catch (IOException e) {
-                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
+                    throw new UncheckedIOException(e);
                 }
             });
-        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Could not load default config sources");
+        } catch (UncheckedIOException e) {
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "Could not load default config sources");
         }
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/ConfigDocuBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/ConfigDocuBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.tools.logging.CuiLogger;
@@ -54,15 +69,15 @@ public class ConfigDocuBean {
                     properties.load(file.openStream());
                     if (properties.containsKey(NAME_KEY)) {
                         String name = properties.getProperty(NAME_KEY);
-                        LOGGER.info("Adding properties %s", name);
+                        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Adding properties %s", name);
                         defaultConfigSources.add(new DefaultConfigSource(file, name, "lang-properties", IOUtils.toString(file.openStream(), StandardCharsets.UTF_8)));
                     }
                 } catch (IOException e) {
-                    throw new RuntimeException(e);
+                    /*~~(TODO: Throw specific not RuntimeException. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/throw new RuntimeException(e);
                 }
             });
-        } catch (Exception e) {
-            LOGGER.error("Could not load default config sources", e);
+        } /*~~(TODO: Catch specific not Exception. Suppress: // cui-rewrite:disable InvalidExceptionUsageRecipe)~~>*/catch (Exception e) {
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Could not load default config sources");
         }
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/CuiIconComponentsPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/CuiIconComponentsPageBean.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/CuiIconsOverviewPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/CuiIconsOverviewPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/CuiTagResolver.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/CuiTagResolver.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.jsf.dev.metadata.LibraryTagLib;

--- a/src/main/java/de/cuioss/portal/reference/pages/IconExtractor.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/IconExtractor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;
@@ -16,7 +31,7 @@ public class IconExtractor {
 
     private final MessageProducer messageProducer;
 
-    private static final CuiLogger log = new CuiLogger(IconExtractor.class);
+    private static final CuiLogger LOGGER = new CuiLogger(IconExtractor.class);
 
     private final FacesContext facesContext;
 
@@ -27,7 +42,7 @@ public class IconExtractor {
     private final String warnOnDuplicateMessageKey;
 
     public IconExtractor(final String cssBefore, final String cuiIconPrefix, final String warnOnDuplicateMessageKey,
-                         final FacesContext facesContext, final MessageProducer messageProducer) {
+        final FacesContext facesContext, final MessageProducer messageProducer) {
         this.facesContext = facesContext;
         this.messageProducer = messageProducer;
         this.cssBefore = cssBefore;
@@ -50,7 +65,7 @@ public class IconExtractor {
                 addIconsToDataList(splitted, data);
             }
         } catch (final IOException e) {
-            log.error("IOException", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "IOException");
         }
 
         return data;
@@ -83,6 +98,6 @@ public class IconExtractor {
     private void warnOnDuplicate(final FacesContext context, final String styleClass) {
         final var errorMessage = messageProducer.getErrorMessageFor(warnOnDuplicateMessageKey, styleClass);
         context.addMessage(null, errorMessage);
-        log.warn("Duplicate icon style for {} found", styleClass);
+        /*~~(TODO: WARN needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.warn("Duplicate icon style for %s found", styleClass);
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/IconExtractor.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/IconExtractor.java
@@ -65,7 +65,8 @@ public class IconExtractor {
                 addIconsToDataList(splitted, data);
             }
         } catch (final IOException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "IOException");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "IOException");
         }
 
         return data;
@@ -98,6 +99,7 @@ public class IconExtractor {
     private void warnOnDuplicate(final FacesContext context, final String styleClass) {
         final var errorMessage = messageProducer.getErrorMessageFor(warnOnDuplicateMessageKey, styleClass);
         context.addMessage(null, errorMessage);
-        /*~~(TODO: WARN needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.warn("Duplicate icon style for %s found", styleClass);
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.warn("Duplicate icon style for %s found", styleClass);
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/MimeTypeIconsPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/MimeTypeIconsPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.jsf.bootstrap.icon.MimeTypeIcon;

--- a/src/main/java/de/cuioss/portal/reference/pages/PrimeFacesIconsOverviewPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/PrimeFacesIconsOverviewPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/AccordionActiveIndexManagerDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/AccordionActiveIndexManagerDemoBean.java
@@ -1,15 +1,29 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.components.support.ActiveIndexManager;
 import de.cuioss.jsf.api.components.support.ActiveIndexManagerImpl;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import jakarta.annotation.PostConstruct;
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/BlockElementBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/BlockElementBean.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Named;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/DataTableProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/DataTableProvider.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Named;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/DataTreeProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/DataTreeProvider.java
@@ -1,14 +1,28 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.primefaces.model.DefaultTreeNode;
 import org.primefaces.model.TreeNode;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -83,7 +97,7 @@ public class DataTreeProvider implements Serializable {
     }
 
     private static void createDrive(final String driverName, final TreeNode<String> parentNode,
-            boolean shouldUseDefaultType) {
+        boolean shouldUseDefaultType) {
         final TreeNode<String> drive = new DefaultTreeNode<>(driverName, parentNode);
         if (!shouldUseDefaultType) {
             drive.setType(DRIVE);
@@ -103,7 +117,7 @@ public class DataTreeProvider implements Serializable {
     }
 
     private static TreeNode<String> createFolder(final String folderName, final TreeNode<String> parent,
-            boolean shouldUseDefaultType) {
+        boolean shouldUseDefaultType) {
         final var folder = new DefaultTreeNode<>(folderName, parent);
         if (!shouldUseDefaultType) {
             folder.setType(FOLDER);
@@ -112,7 +126,7 @@ public class DataTreeProvider implements Serializable {
     }
 
     private static TreeNode<String> createFile(final String fileName, final TreeNode<String> parent,
-            boolean shouldUseDefaultType) {
+        boolean shouldUseDefaultType) {
         final var fileNode = new DefaultTreeNode<>(fileName, parent);
         if (!shouldUseDefaultType) {
             fileNode.setType(FILE);

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBean.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.tools.logging.CuiLogger;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -17,7 +31,7 @@ import java.io.Serializable;
 @ToString
 public class DialogDemoPageBean implements Serializable {
 
-    private static final CuiLogger log = new CuiLogger(DialogDemoPageBean.class);
+    private static final CuiLogger LOGGER = new CuiLogger(DialogDemoPageBean.class);
 
     @Serial
     private static final long serialVersionUID = 3744529779452625817L;
@@ -41,7 +55,7 @@ public class DialogDemoPageBean implements Serializable {
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
-            log.error("Error loading lazy dialog content", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Error loading lazy dialog content");
             Thread.currentThread().interrupt();
         }
         lazyLoadingDialogContentAvailable = true;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBean.java
@@ -55,7 +55,8 @@ public class DialogDemoPageBean implements Serializable {
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Error loading lazy dialog content");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "Error loading lazy dialog content");
             Thread.currentThread().interrupt();
         }
         lazyLoadingDialogContentAvailable = true;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListDemoPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListDemoPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.components.model.datalist.EditableDataListModel;
@@ -7,14 +22,13 @@ import de.cuioss.jsf.bootstrap.layout.LayoutMode;
 import de.cuioss.portal.reference.pages.demo.Address;
 import de.cuioss.portal.reference.pages.demo.AddressGenerator;
 import de.cuioss.test.generator.Generators;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import jakarta.annotation.PostConstruct;
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -23,7 +37,7 @@ import java.util.List;
 
 @Named
 @SessionScoped
-@EqualsAndHashCode(exclude = { "addressModel" })
+@EqualsAndHashCode(exclude = {"addressModel"})
 @ToString
 public class EditableDataListDemoPageBean implements Serializable {
 

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListValidator.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListValidator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.components.model.datalist.EditableDataListModel;
@@ -12,7 +27,7 @@ public class EditableDataListValidator extends AbstractValidator<EditableDataLis
 
     @Override
     protected void validateTypeSave(final FacesContext context, final UIComponent component,
-                                    final EditableDataListModel<?> model) {
+        final EditableDataListModel<?> model) {
         if (null != model && model.getResultItems().size() == 5) {
             throwValidatorException("page.editabledatalist.validationerror");
         }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/EncapsulateLazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/EncapsulateLazyLoadingPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.tools.base.Preconditions;
@@ -44,20 +59,20 @@ public class EncapsulateLazyLoadingPageBean implements Serializable {
     }
 
     public void initialize() {
-        LOGGER.info("Entering initialize at %s", LocalDateTime.now());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering initialize at %s", LocalDateTime.now());
         try {
             TimeUnit.SECONDS.sleep(3);
             Preconditions.checkState(parentContainerRendered, "In case parent CC isn't rendered, this code shouldn't be invoked, otherwise wrong behaviour");
         } catch (InterruptedException e) {
-            LOGGER.error("interrupted: ", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
-        LOGGER.info("Leaving initialize at %s", LocalDateTime.now());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Leaving initialize at %s", LocalDateTime.now());
         this.content = mutableList("A", "B", "C");
     }
 
     public void switchOverParentContainerRendered() {
-        LOGGER.info("Entering switchOverParentContainerRendered at %s", LocalDateTime.now());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering switchOverParentContainerRendered at %s", LocalDateTime.now());
         this.parentContainerRendered = !parentContainerRendered;
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/EncapsulateLazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/EncapsulateLazyLoadingPageBean.java
@@ -59,20 +59,24 @@ public class EncapsulateLazyLoadingPageBean implements Serializable {
     }
 
     public void initialize() {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering initialize at %s", LocalDateTime.now());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Entering initialize at %s", LocalDateTime.now());
         try {
             TimeUnit.SECONDS.sleep(3);
             Preconditions.checkState(parentContainerRendered, "In case parent CC isn't rendered, this code shouldn't be invoked, otherwise wrong behaviour");
         } catch (InterruptedException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Leaving initialize at %s", LocalDateTime.now());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Leaving initialize at %s", LocalDateTime.now());
         this.content = mutableList("A", "B", "C");
     }
 
     public void switchOverParentContainerRendered() {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering switchOverParentContainerRendered at %s", LocalDateTime.now());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Entering switchOverParentContainerRendered at %s", LocalDateTime.now());
         this.parentContainerRendered = !parentContainerRendered;
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/InputGuardDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/InputGuardDemoBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingPageBean.java
@@ -53,20 +53,26 @@ public class LazyLoadingPageBean extends BaseLazyLoadingRequest<List<String>> im
     private List<String> content;
 
     public void startInitialize() {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Executing startInitialize");
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Executing startInitialize");
         viewController.startRequest(this);
     }
 
+    // ResultObject is deprecated but still required by LazyLoadingRequest API
+    @SuppressWarnings("deprecation")
     @Override
     public ResultObject<List<String>> backendRequest() {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering BackendRequest at %s", LocalDateTime.now());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Entering BackendRequest at %s", LocalDateTime.now());
         try {
             TimeUnit.SECONDS.sleep(10);
         } catch (InterruptedException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Leaving BackendRequest at %s", LocalDateTime.now());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Leaving BackendRequest at %s", LocalDateTime.now());
         return new ResultObject<>(mutableList("A", "B", "C"), ResultState.VALID);
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.portal.ui.api.lazyloading.BaseLazyLoadingRequest;
@@ -38,20 +53,20 @@ public class LazyLoadingPageBean extends BaseLazyLoadingRequest<List<String>> im
     private List<String> content;
 
     public void startInitialize() {
-        LOGGER.info("Executing startInitialize");
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Executing startInitialize");
         viewController.startRequest(this);
     }
 
     @Override
     public ResultObject<List<String>> backendRequest() {
-        LOGGER.info("Entering BackendRequest at %s", LocalDateTime.now());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Entering BackendRequest at %s", LocalDateTime.now());
         try {
             TimeUnit.SECONDS.sleep(10);
         } catch (InterruptedException e) {
-            LOGGER.error("interrupted: ", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
-        LOGGER.info("Leaving BackendRequest at %s", LocalDateTime.now());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Leaving BackendRequest at %s", LocalDateTime.now());
         return new ResultObject<>(mutableList("A", "B", "C"), ResultState.VALID);
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingWithoutBackendPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/LazyLoadingWithoutBackendPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import jakarta.faces.view.ViewScoped;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/MultipleLazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/MultipleLazyLoadingPageBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.portal.ui.api.lazyloading.BaseLazyLoadingRequest;
@@ -28,7 +43,7 @@ public class MultipleLazyLoadingPageBean extends BaseLazyLoadingRequest<List<Str
     @Serial
     private static final long serialVersionUID = 3231631758524048548L;
 
-    private static final CuiLogger log = new CuiLogger(MultipleLazyLoadingPageBean.class);
+    private static final CuiLogger LOGGER = new CuiLogger(MultipleLazyLoadingPageBean.class);
 
     @Inject
     LazyLoadingViewController viewController;
@@ -50,7 +65,7 @@ public class MultipleLazyLoadingPageBean extends BaseLazyLoadingRequest<List<Str
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
-            log.error("interrupted: ", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
         return new ResultObject<>(mutableList("A", "B", "C"), ResultState.VALID);

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/MultipleLazyLoadingPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/MultipleLazyLoadingPageBean.java
@@ -60,12 +60,15 @@ public class MultipleLazyLoadingPageBean extends BaseLazyLoadingRequest<List<Str
         return null;
     }
 
+    // ResultObject is deprecated but still required by LazyLoadingRequest API
+    @SuppressWarnings("deprecation")
     @Override
     public ResultObject<List<String>> backendRequest() {
         try {
             Thread.sleep(5000);
         } catch (InterruptedException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "interrupted: ");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "interrupted: ");
             Thread.currentThread().interrupt();
         }
         return new ResultObject<>(mutableList("A", "B", "C"), ResultState.VALID);

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/NavigationMenuDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/NavigationMenuDemoBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.application.navigation.NavigationUtils;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/NotificationBoxHandler.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/NotificationBoxHandler.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.components.events.ModelPayloadEvent;
 import de.cuioss.tools.logging.CuiLogger;
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
-
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Named;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -18,7 +32,7 @@ import java.util.*;
 @ToString
 public class NotificationBoxHandler implements Serializable {
 
-    private static final CuiLogger log = new CuiLogger(NotificationBoxHandler.class);
+    private static final CuiLogger LOGGER = new CuiLogger(NotificationBoxHandler.class);
 
     @Serial
     private static final long serialVersionUID = 4046443512030148754L;
@@ -26,10 +40,10 @@ public class NotificationBoxHandler implements Serializable {
     private final SortedSet<Date> dismissCalls = new TreeSet<>(Comparator.comparingLong(Date::getTime));
 
     public void dismissedListener(final ModelPayloadEvent dismissEvent) {
-        log.debug("Dismiss called '{}'", dismissEvent);
+        LOGGER.debug("Dismiss called '%s'", dismissEvent);
         dismissCalls.add(new Date());
         if (dismissCalls.size() > 5) {
-            dismissCalls.remove(dismissCalls.first());
+            dismissCalls.remove(dismissCalls.getFirst());
         }
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProvider.java
@@ -1,14 +1,28 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.ui.model.ToggleSwitch;
 import de.cuioss.tools.logging.CuiLogger;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -26,7 +40,7 @@ import java.time.format.DateTimeFormatter;
 @ToString
 public class PanelDemoProvider implements Serializable {
 
-    private static final CuiLogger log = new CuiLogger(PanelDemoProvider.class);
+    private static final CuiLogger LOGGER = new CuiLogger(PanelDemoProvider.class);
 
     @Serial
     private static final long serialVersionUID = 260766844925472554L;
@@ -43,14 +57,14 @@ public class PanelDemoProvider implements Serializable {
      * @return test data with delay
      */
     public String getData() {
-        log.debug("Delayed data request started. waiting some time...");
+        LOGGER.debug("Delayed data request started. waiting some time...");
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
-            log.error("Delayed data delivery interrupted", e);
+            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Delayed data delivery interrupted");
             Thread.currentThread().interrupt();
         }
-        log.debug("Delivering delayed data.");
+        LOGGER.debug("Delivering delayed data.");
         return "Delayed data, called at: " + LocalDateTime.now().format(DateTimeFormatter.ISO_TIME);
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProvider.java
@@ -61,7 +61,8 @@ public class PanelDemoProvider implements Serializable {
         try {
             Thread.sleep(2000);
         } catch (InterruptedException e) {
-            /*~~(TODO: ERROR needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.error(e, "Delayed data delivery interrupted");
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.error(e, "Delayed data delivery interrupted");
             Thread.currentThread().interrupt();
         }
         LOGGER.debug("Delivering delayed data.");

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/PickListDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/PickListDemoBean.java
@@ -1,15 +1,29 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.tools.logging.CuiLogger;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.primefaces.event.TransferEvent;
 import org.primefaces.model.DualListModel;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -26,15 +40,15 @@ public class PickListDemoBean implements Serializable {
     @Serial
     private static final long serialVersionUID = -4722969015860606113L;
 
-    private static final CuiLogger log = new CuiLogger(PickListDemoBean.class);
+    private static final CuiLogger LOGGER = new CuiLogger(PickListDemoBean.class);
 
     @Getter
     @Setter
     private DualListModel<String> picklistModel = new DualListModel<>(immutableList("one", "two", "three"),
-            immutableList("four", "five", "six"));
+        immutableList("four", "five", "six"));
 
     public void sortListener(final TransferEvent event) {
-        log.debug(event.toString());
+        LOGGER.debug(event.toString());
         Collections.sort(picklistModel.getTarget());
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/SchedulerBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/SchedulerBean.java
@@ -1,12 +1,26 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import lombok.Getter;
-import org.primefaces.model.DefaultScheduleEvent;
-import org.primefaces.model.DefaultScheduleModel;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Named;
+import lombok.Getter;
+import org.primefaces.model.DefaultScheduleEvent;
+import org.primefaces.model.DefaultScheduleModel;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/SwitchDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/SwitchDemoBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
@@ -10,7 +10,7 @@ import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.domain.NameGenerators;
 import de.cuioss.tools.logging.CuiLogger;
 import de.cuioss.tools.string.Joiner;
-import de.cuioss.uimodel.model.conceptkey.AugmentationKeyConstans;
+import de.cuioss.uimodel.model.conceptkey.AugmentationKeyConstants;
 import de.cuioss.uimodel.model.conceptkey.ConceptCategory;
 import de.cuioss.uimodel.model.conceptkey.ConceptKeyType;
 import de.cuioss.uimodel.model.conceptkey.impl.ConceptKeyTypeImpl;
@@ -88,7 +88,7 @@ public class TagDataProvider implements Serializable {
         @Override
         public ConceptKeyType createUndefinedConceptKey(final String value) {
             return ConceptKeyTypeImpl.builder().identifier(value).labelResolver(new I18nDisplayNameProvider(value))
-                .category(this).augmentation(AugmentationKeyConstans.UNDEFINED_VALUE, Boolean.TRUE.toString())
+                .category(this).augmentation(AugmentationKeyConstants.UNDEFINED_VALUE, Boolean.TRUE.toString())
                 .build();
         }
     };

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
@@ -131,7 +131,8 @@ public class TagDataProvider implements Serializable {
     }
 
     public List<String> getFirstNames() {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Available firstnames : %s", firstNames);
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Available firstnames : %s", firstNames);
         return firstNames;
     }
 
@@ -142,7 +143,8 @@ public class TagDataProvider implements Serializable {
      *                     element
      */
     public void disposeListener(final ModelPayloadEvent disposeEvent) {
-        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Dispose : %s", disposeEvent.getModel());
+        // cui-rewrite:disable CuiLogRecordPatternRecipe
+        LOGGER.info("Dispose : %s", disposeEvent.getModel());
         firstNames.remove(disposeEvent.getModel());
         messageProducer.addGlobalMessage("Disposed=" + disposeEvent.getModel(), FacesMessage.SEVERITY_INFO);
     }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TagDataProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;
@@ -49,7 +64,7 @@ public class TagDataProvider implements Serializable {
     @Serial
     private static final long serialVersionUID = -3513331142570721330L;
 
-    private static final CuiLogger log = new CuiLogger(TagDataProvider.class);
+    private static final CuiLogger LOGGER = new CuiLogger(TagDataProvider.class);
 
     @Inject
     MessageProducer messageProducer;
@@ -116,7 +131,7 @@ public class TagDataProvider implements Serializable {
     }
 
     public List<String> getFirstNames() {
-        log.info("Available firstnames : {}", firstNames);
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Available firstnames : %s", firstNames);
         return firstNames;
     }
 
@@ -127,7 +142,7 @@ public class TagDataProvider implements Serializable {
      *                     element
      */
     public void disposeListener(final ModelPayloadEvent disposeEvent) {
-        log.info("Dispose : {}", disposeEvent.getModel());
+        /*~~(TODO: INFO needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.info("Dispose : %s", disposeEvent.getModel());
         firstNames.remove(disposeEvent.getModel());
         messageProducer.addGlobalMessage("Disposed=" + disposeEvent.getModel(), FacesMessage.SEVERITY_INFO);
     }
@@ -158,7 +173,7 @@ public class TagDataProvider implements Serializable {
     public void validate(final FacesContext context, final UIComponent component, final Object value) {
         if (null != value) {
             final var items = (Set<ConceptKeyType>) value;
-            final Set<String> blacklist = immutableSet(firstNames.get(0), firstNames.get(1));
+            final Set<String> blacklist = immutableSet(firstNames.getFirst(), firstNames.get(1));
             if (items.stream().anyMatch(c -> blacklist.contains(c.getIdentifier()))) {
                 throw new ValidatorException(new FacesMessage(FacesMessage.SEVERITY_ERROR,
                     "Don't add any of: " + blacklist, "Don't add any of: " + blacklist));

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TextEditorDemoPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TextEditorDemoPageBean.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import lombok.Getter;
-import lombok.Setter;
 
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Named;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TextFilterBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TextFilterBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.test.generator.domain.FullNameGenerator;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/TypewatchHandlerBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/TypewatchHandlerBean.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.tools.string.MoreStrings;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/WidgetBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/WidgetBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.portal.ui.api.dashboard.BaseLazyLoadingWidget;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/WidgetBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/WidgetBean.java
@@ -57,6 +57,8 @@ public class WidgetBean extends BaseLazyLoadingWidget<String> {
     @Getter
     private int repeats;
 
+    // ResultObject is deprecated but still required by BaseLazyLoadingWidget API
+    @SuppressWarnings("deprecation")
     @Override
     public ResultObject<String> backendRequest() {
         if (random.nextInt() % 3 != 0) {

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/WizardDemoBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/WizardDemoBean.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKey.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKey.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo.support;
 
 import de.cuioss.jsf.api.security.SanitizedIDNInternetAddress;

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKey.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKey.java
@@ -3,7 +3,7 @@ package de.cuioss.portal.reference.pages.components.demo.support;
 import de.cuioss.jsf.api.security.SanitizedIDNInternetAddress;
 import de.cuioss.tools.string.Joiner;
 import de.cuioss.tools.string.MoreStrings;
-import de.cuioss.uimodel.model.conceptkey.AugmentationKeyConstans;
+import de.cuioss.uimodel.model.conceptkey.AugmentationKeyConstants;
 import de.cuioss.uimodel.model.conceptkey.ConceptKeyType;
 import de.cuioss.uimodel.model.conceptkey.impl.BaseConceptCategory;
 import de.cuioss.uimodel.model.conceptkey.impl.BaseConceptKeyType;
@@ -15,6 +15,8 @@ import lombok.ToString;
 import lombok.experimental.Delegate;
 
 import java.io.Serial;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Locale;
 
 /**
@@ -46,7 +48,7 @@ public class AddressConceptKey extends BaseConceptKeyType {
      *                     null
      */
     public AddressConceptKey(@NonNull final AddressEntry addressEntry) {
-        super(new AddressConceptCategory());
+        super(Collections.emptySet(), new HashMap<>(), new AddressConceptCategory());
         delegateAddress = addressEntry;
         identifier = Joiner.on("").skipNulls().join(delegateAddress.getMailAddress(), delegateAddress.getId());
         labelResolver = createResolver();
@@ -61,7 +63,7 @@ public class AddressConceptKey extends BaseConceptKeyType {
      */
     public AddressConceptKey(final AddressEntry addressEntry, final boolean undefined) {
         this(addressEntry);
-        super.set(AugmentationKeyConstans.UNDEFINED_VALUE, Boolean.toString(undefined));
+        super.set(AugmentationKeyConstants.UNDEFINED_VALUE, Boolean.toString(undefined));
     }
 
     private I18nDisplayNameProvider createResolver() {

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKeyConverter.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressConceptKeyConverter.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo.support;
 
 import de.cuioss.jsf.api.converter.AbstractConverter;
@@ -19,7 +34,7 @@ public class AddressConceptKeyConverter extends AbstractConverter<AddressConcept
 
     @Override
     public AddressConceptKey convertToObject(final FacesContext context, final UIComponent component,
-                                             final String value) throws ConverterException {
+        final String value) throws ConverterException {
         if (MoreStrings.isBlank(value)) {
             return null;
         }
@@ -29,7 +44,7 @@ public class AddressConceptKeyConverter extends AbstractConverter<AddressConcept
 
     @Override
     protected String convertToString(final FacesContext context, final UIComponent component,
-                                     final AddressConceptKey value) throws ConverterException {
+        final AddressConceptKey value) throws ConverterException {
 
         return value.getResolved(null);
     }

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressEntry.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressEntry.java
@@ -31,7 +31,7 @@ import static java.util.Objects.isNull;
 /**
  * Represents an Address that can be used in conjunction with provider search
  * and email-addressing. It provides at least an email-address
- * ({@link #getMailAddress()}) and an unique identifier ({@link #getId()})
+ * ({@code mailAddress}) and a unique identifier ({@code id})
  */
 @Value
 @Builder
@@ -72,7 +72,7 @@ public class AddressEntry implements IDisplayNameProvider<String>, Comparable<Ad
     private final String id = UUID.randomUUID().toString();
 
     /**
-     * @return the displayed {@link #getPersonName()} and {@link #getOrganization()}
+     * @return the displayed {@code personName} and {@code organization}
      */
     public String buildPersonal() {
         var personal = Optional.ofNullable(personNameWithTitle).orElse(personName);

--- a/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressEntry.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/components/demo/support/AddressEntry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo.support;
 
 import de.cuioss.tools.string.MoreStrings;

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/Address.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/Address.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo;
 
 import lombok.Data;

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/AddressFormat.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/AddressFormat.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo;
 
 import de.cuioss.tools.collect.MapBuilder;
@@ -25,8 +40,8 @@ public class AddressFormat implements Serializable {
     private String pattern;
 
     private static final Map<String, IDisplayNameProvider<String>> LABEL_MAP = new MapBuilder<String, IDisplayNameProvider<String>>()
-            .put("city", new DisplayName("City")).put("street", new DisplayName("Street"))
-            .put("line1", new DisplayName("Line 1")).put("line2", new DisplayName("Line 2")).toMutableMap();
+        .put("city", new DisplayName("City")).put("street", new DisplayName("Street"))
+        .put("line1", new DisplayName("Line 1")).put("line2", new DisplayName("Line 2")).toMutableMap();
 
     /**
      * @param address to be formatted
@@ -59,7 +74,7 @@ public class AddressFormat implements Serializable {
 
         final var builder = new MapBuilder<String, String>();
         builder.put("city", address.getCity()).put("street", address.getStreet()).put("line1", address.getLine1())
-                .put("line2", address.getLine2());
+            .put("line2", address.getLine2());
         return builder.toMutableMap();
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/AddressGenerator.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/AddressGenerator.java
@@ -1,7 +1,7 @@
 package de.cuioss.portal.reference.pages.demo;
 
+import de.cuioss.test.generator.Generators;
 import de.cuioss.test.generator.TypedGenerator;
-import de.cuioss.test.generator.internal.net.java.quickcheck.generator.PrimitiveGenerators;
 
 import static de.cuioss.test.generator.Generators.fixedValues;
 import static de.cuioss.test.generator.Generators.integers;
@@ -27,7 +27,7 @@ public class AddressGenerator implements TypedGenerator<Address> {
         address.setCity(CITIES.next());
         address.setStreet(getAddressLine());
         address.setLine1(getAddressLine());
-        address.setEditable(PrimitiveGenerators.booleans().next());
+        address.setEditable(Generators.booleans().next());
         return address;
     }
 

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/AddressGenerator.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/AddressGenerator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo;
 
 import de.cuioss.test.generator.Generators;
@@ -14,12 +29,12 @@ import static de.cuioss.test.generator.Generators.integers;
 public class AddressGenerator implements TypedGenerator<Address> {
 
     private static final TypedGenerator<String> STREET_NAMES = fixedValues("Hautpstr.", "Nebengäßchen", "Other Street",
-            "That Street");
+        "That Street");
 
     private static final TypedGenerator<Integer> STREET_NUMBERS = integers(1, 128);
 
     private static final TypedGenerator<String> CITIES = fixedValues("Walldorf", "Heidelberg", "Mannheim", "Wiesloch",
-            "Karlsruhe", "München", "Baden Baden", "Ludwigshafen");
+        "Karlsruhe", "München", "Baden Baden", "Ludwigshafen");
 
     @Override
     public Address next() {

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/AddressPageBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/AddressPageBean.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo;
-
-import lombok.EqualsAndHashCode;
-import lombok.ToString;
 
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Named;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/LabeledData.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/LabeledData.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo;
 
 import de.cuioss.uimodel.nameprovider.IDisplayNameProvider;

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/graph/GraphDemoPage.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/graph/GraphDemoPage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.demo.graph;
 
 import de.cuioss.jsf.jqplot.JqPlot;
@@ -14,12 +29,11 @@ import de.cuioss.jsf.jqplot.options.legend.Placement;
 import de.cuioss.jsf.jqplot.renderer.marker.MarkerRendererOptions;
 import de.cuioss.jsf.jqplot.renderer.marker.PointStyle;
 import de.cuioss.test.generator.Generators;
-import lombok.Getter;
-import lombok.Setter;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.inject.Named;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -86,7 +100,7 @@ public class GraphDemoPage implements Serializable {
 
         // adaptation of seria (aka. Ticks) does follow the order of added seria data
         twoLineGraphOptions.addSeriaOption(Series.createAsListElement().setColor(firstSeriaColor)
-                .setLabel(firstSeriaLabel).setMarkerOptions(new MarkerRendererOptions().setStyle(PointStyle.CIRCLE)));
+            .setLabel(firstSeriaLabel).setMarkerOptions(new MarkerRendererOptions().setStyle(PointStyle.CIRCLE)));
 
         return new JqPlot("twoLinesChart", twoLineSeriaData, twoLineGraphOptions);
     }

--- a/src/main/java/de/cuioss/portal/reference/pages/demo/package-info.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/demo/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * The package is used for playground
  */

--- a/src/main/java/de/cuioss/portal/reference/pages/docu/components/demo/CommandButtonsDemoPage.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/docu/components/demo/CommandButtonsDemoPage.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.docu.components.demo;
 
 import de.cuioss.jsf.api.application.message.MessageProducer;

--- a/src/main/java/de/cuioss/portal/reference/pages/docu/components/demo/LabeledContainerDemoPage.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/docu/components/demo/LabeledContainerDemoPage.java
@@ -1,13 +1,27 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.docu.components.demo;
 
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 import org.primefaces.model.DualListModel;
-
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Named;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBean.java
@@ -1,15 +1,29 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal;
 
 import de.cuioss.portal.ui.api.templating.PortalTemplateDescriptor;
 import de.cuioss.portal.ui.runtime.application.templating.PortalCoreTemplates;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBean.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBean.java
@@ -1,7 +1,7 @@
 package de.cuioss.portal.reference.pages.portal;
 
 import de.cuioss.portal.ui.api.templating.PortalTemplateDescriptor;
-import de.cuioss.portal.ui.runtime.application.templating.PortalTemplates;
+import de.cuioss.portal.ui.runtime.application.templating.PortalCoreTemplates;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -33,7 +33,7 @@ public class PortalTemplateBean implements Serializable {
 
     @Inject
     @PortalTemplateDescriptor
-    PortalTemplates portalTemplates;
+    PortalCoreTemplates portalTemplates;
 
     @Getter
     private List<TemplateDescriptor> templateDescriptor;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/Section.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/Section.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/TemplateDescriptor.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/TemplateDescriptor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal;
 
 import de.cuioss.tools.io.IOStreams;
@@ -77,7 +92,7 @@ public class TemplateDescriptor implements Serializable {
             description = NO_DECRIPTION_FOUND;
             sections = Collections.emptyList();
         } else {
-            final var wrappedComment = wrappDescription(comments.iterator().next());
+            final var wrappedComment = wrappDescription(comments.getFirst());
             description = extractDescription(wrappedComment);
             sections = extractSections(wrappedComment);
         }
@@ -117,7 +132,7 @@ public class TemplateDescriptor implements Serializable {
         }
         final var commentString = comment.getText().trim();
         if (commentString.startsWith(DOCUMENTATION_START_ELEMENT)
-                && commentString.endsWith(DOCUMENTATION_END_ELEMENT)) {
+            && commentString.endsWith(DOCUMENTATION_END_ELEMENT)) {
             Document document = null;
             try (var inputStream = IOStreams.toInputStream(commentString)) {
                 document = secureSaxBuilder().build(inputStream);
@@ -138,7 +153,7 @@ public class TemplateDescriptor implements Serializable {
         final List<Section> result = new ArrayList<>();
         for (final Element extractedSection : extractedSections) {
             result.add(new Section(extractedSection.getChildText(TITLE_ELEMENT),
-                    new XMLOutputter().outputString(extractedSection.getChild(BODY_ELEMENT).getContent())));
+                new XMLOutputter().outputString(extractedSection.getChild(BODY_ELEMENT).getContent())));
         }
         return result;
     }

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/BundleDescripor.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/BundleDescripor.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal.bundle;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/BundleEntry.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/BundleEntry.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal.bundle;
 
 import lombok.Data;

--- a/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/ResourceBundleOverview.java
+++ b/src/main/java/de/cuioss/portal/reference/pages/portal/bundle/ResourceBundleOverview.java
@@ -1,15 +1,30 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal.bundle;
 
 import de.cuioss.portal.common.bundle.ResourceBundleLocator;
 import de.cuioss.portal.common.bundle.ResourceBundleRegistry;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -44,7 +59,7 @@ public class ResourceBundleOverview implements Serializable {
         descriptors = new ArrayList<>();
         for (ResourceBundleLocator locator : bundleRegistry.getResolvedPaths()) {
             descriptors.add(new BundleDescripor(locator.getBundlePath().orElse("unknown"),
-                    locator.getBundle(Locale.getDefault()).orElseThrow(() -> new IllegalStateException("No bundle found for %s".formatted(locator)))));
+                locator.getBundle(Locale.getDefault()).orElseThrow(() -> new IllegalStateException("No bundle found for %s".formatted(locator)))));
         }
     }
 }

--- a/src/main/java/de/cuioss/portal/reference/portal/ReferenceTemplates.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/ReferenceTemplates.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal;
 
 import de.cuioss.portal.common.priority.PortalPriorities;

--- a/src/main/java/de/cuioss/portal/reference/portal/application/ReferenceBundle.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/application/ReferenceBundle.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.application;
 
 import de.cuioss.portal.common.bundle.ResourceBundleLocator;
@@ -49,7 +64,7 @@ public class ReferenceBundle implements ResourceBundleLocator {
             LOGGER.debug("Successfully loaded %s '%s' for '%s'", getClass().getName(), PATH, locale);
             return loadedBundle;
         } catch (MissingResourceException e) {
-            LOGGER.warn("Unable to load %s '%s' for '%s'".formatted(getClass().getName(), PATH, locale), e);
+            /*~~(TODO: WARN needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.warn(e, "Unable to load %s '%s' for '%s'".formatted(getClass().getName(), PATH, locale));
             return Optional.empty();
         }
     }

--- a/src/main/java/de/cuioss/portal/reference/portal/application/ReferenceBundle.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/application/ReferenceBundle.java
@@ -64,7 +64,8 @@ public class ReferenceBundle implements ResourceBundleLocator {
             LOGGER.debug("Successfully loaded %s '%s' for '%s'", getClass().getName(), PATH, locale);
             return loadedBundle;
         } catch (MissingResourceException e) {
-            /*~~(TODO: WARN needs LogRecord. Suppress: // cui-rewrite:disable CuiLogRecordPatternRecipe)~~>*/LOGGER.warn(e, "Unable to load %s '%s' for '%s'".formatted(getClass().getName(), PATH, locale));
+            // cui-rewrite:disable CuiLogRecordPatternRecipe
+            LOGGER.warn(e, "Unable to load %s '%s' for '%s'".formatted(getClass().getName(), PATH, locale));
             return Optional.empty();
         }
     }

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/ReferenceMenuProvider.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/ReferenceMenuProvider.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/BootstrapMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/BootstrapMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/CuiComponentsMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/CuiComponentsMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/ExternalComponentsMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/ExternalComponentsMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/GettingStartedMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/GettingStartedMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/IconMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/IconMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/MenuItemSeparator.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/MenuItemSeparator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSeparatorImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PagesMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PagesMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PortalMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PortalMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PrimefacesMenu.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/PrimefacesMenu.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/BootstrapGridMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/BootstrapGridMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.bootstrap;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/CuiLabeledContainerMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/CuiLabeledContainerMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.bootstrap;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/CuiLayoutMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/CuiLayoutMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.bootstrap;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/FormMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/bootstrap/FormMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.bootstrap;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiBehaviorMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiBehaviorMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiConverterMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiConverterMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiUiComponentsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiUiComponentsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiValidatorMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/CuiValidatorMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiButtonsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiButtonsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiCommandButtonsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiCommandButtonsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiDashboardMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiDashboardMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiEditableDatalistMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiEditableDatalistMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiFieldsetMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiFieldsetMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiInputGuardedMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiInputGuardedMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiLazyLoadingMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiLazyLoadingMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiMiscellaneousMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiMiscellaneousMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiPanelMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiPanelMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;
@@ -23,7 +38,7 @@ public class CuiPanelMenuItem extends NavigationMenuItemSingleImpl {
 
     /** The icon for this item. */
     public static final String ICON = "cui-icon-nameplate_alt"; // alternatives: cui-icon-sort,
-                                                                // cui-icon-show_thumbnails
+    // cui-icon-show_thumbnails
 
     /** The icon for this item. */
     public static final String OUTCOME = "cui_panel";

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiTagMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiTagMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiTextFilterMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiTextFilterMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiToolbarMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/CuiToolbarMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/DisplayNameProviderMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/DisplayNameProviderMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/JqPlotMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/JqPlotMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/ModalDialogDemoMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/cui/demo/ModalDialogDemoMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.cui.demo;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/JSFCoreMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/JSFCoreMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.external;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/JSFHtmlMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/JSFHtmlMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.external;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/OmnifacesMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/OmnifacesMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.external;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/PrimefacesMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/external/PrimefacesMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.external;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/CuiIconMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/CuiIconMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.icon;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/IconComponentsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/IconComponentsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.icon;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/MimeTypeIconMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/MimeTypeIconMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.icon;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/PrimeFacesCuiIconMappingMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/icon/PrimeFacesCuiIconMappingMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.icon;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ArchitectureMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ArchitectureMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/BasicConceptsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/BasicConceptsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/CommonObjectsMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/CommonObjectsMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ConnectionMetadataMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ConnectionMetadataMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ErrorHandlingMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/ErrorHandlingMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/I18nMessagesMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/I18nMessagesMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/LocaleHandlingMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/LocaleHandlingMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalBaseMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalBaseMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import de.cuioss.jsf.api.application.navigation.NavigationUtils;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalCoreMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalCoreMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItem;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalResourceBundlesMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalResourceBundlesMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import lombok.EqualsAndHashCode;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalTemplatesMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/portal/PortalTemplatesMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.portal;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesPicklistMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesPicklistMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesSchedulerMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesSchedulerMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTableMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTableMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTextEditorMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTextEditorMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTreeMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesTreeMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesWizardMenuItem.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/navigation/items/prime/PrimefacesWizardMenuItem.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.navigation.items.prime;
 
 import de.cuioss.jsf.api.components.model.menu.NavigationMenuItemSingleImpl;

--- a/src/main/java/de/cuioss/portal/reference/portal/package-info.java
+++ b/src/main/java/de/cuioss/portal/reference/portal/package-info.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /**
  * Defines the portal specific classes.
  *

--- a/src/test/java/de/cuioss/portal/reference/pages/ConfigDocuBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/ConfigDocuBeanTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.test.juli.LogAsserts;
@@ -22,8 +37,8 @@ class ConfigDocuBeanTest {
         final var result = underTest.getDefaultConfigSources();
         assertNotNull(result);
         assertEquals(2, result.size());
-        assertNotNull(result.get(0).getPath());
-        assertNotNull(result.get(0).getLang());
+        assertNotNull(result.getFirst().getPath());
+        assertNotNull(result.getFirst().getLang());
         LogAsserts.assertNoLogMessagePresent(TestLogLevel.ERROR, ConfigDocuBean.class);
     }
 }

--- a/src/test/java/de/cuioss/portal/reference/pages/CuiTagResolverTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/CuiTagResolverTest.java
@@ -1,14 +1,27 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.test.valueobjects.junit5.contracts.ShouldHandleObjectContracts;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @EnablePortalUiEnvironment
 class CuiTagResolverTest implements ShouldHandleObjectContracts<CuiTagResolver> {

--- a/src/test/java/de/cuioss/portal/reference/pages/ModuleConsistencyTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/ModuleConsistencyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages;
 
 import de.cuioss.portal.core.test.tests.BaseModuleConsistencyTest;

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/AccordionActiveIndexManagerDemoBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/AccordionActiveIndexManagerDemoBeanTest.java
@@ -1,10 +1,24 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
 import de.cuioss.test.valueobjects.api.object.ObjectTestConfig;
+import jakarta.inject.Inject;
 import lombok.Getter;
 
 @EnablePortalUiEnvironment

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/DataTableProviderTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/DataTableProviderTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
 
 @EnablePortalUiEnvironment

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/DataTreeProviderTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/DataTreeProviderTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
 
 @EnablePortalUiEnvironment

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/DialogDemoPageBeanTest.java
@@ -1,15 +1,28 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnablePortalUiEnvironment
 class DialogDemoPageBeanTest extends AbstractPageBeanTest<DialogDemoPageBean> {

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListDemoPageBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/EditableDataListDemoPageBeanTest.java
@@ -1,15 +1,28 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @EnablePortalUiEnvironment
 class EditableDataListDemoPageBeanTest extends AbstractPageBeanTest<EditableDataListDemoPageBean> {

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/InputGuardDemoBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/InputGuardDemoBeanTest.java
@@ -1,15 +1,28 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
-
-import org.jboss.weld.junit5.auto.AddBeanClasses;
 
 import de.cuioss.jsf.api.application.message.MessageProducerBean;
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
 import de.cuioss.test.valueobjects.api.contracts.VerifyBeanProperty;
 import de.cuioss.test.valueobjects.api.property.PropertyReflectionConfig;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
 
 @EnablePortalUiEnvironment
 @VerifyBeanProperty

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/NavigationMenuDemoBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/NavigationMenuDemoBeanTest.java
@@ -1,17 +1,30 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
-
-import org.jboss.weld.junit5.auto.AddBeanClasses;
 
 import de.cuioss.portal.core.test.mocks.authentication.PortalAuthenticationFacadeMock;
 import de.cuioss.portal.core.test.mocks.authentication.PortalTestUserProducer;
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
 
 @EnablePortalUiEnvironment
-@AddBeanClasses({ PortalAuthenticationFacadeMock.class, PortalTestUserProducer.class })
+@AddBeanClasses({PortalAuthenticationFacadeMock.class, PortalTestUserProducer.class})
 class NavigationMenuDemoBeanTest extends AbstractPageBeanTest<NavigationMenuDemoBean> {
 
     @Inject

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/NotificationBoxHandlerTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/NotificationBoxHandlerTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
 
 @EnablePortalUiEnvironment

--- a/src/test/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProviderTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/components/demo/PanelDemoProviderTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.components.demo;
-
-import jakarta.inject.Inject;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
 
 @EnablePortalUiEnvironment

--- a/src/test/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBeanTest.java
+++ b/src/test/java/de/cuioss/portal/reference/pages/portal/PortalTemplateBeanTest.java
@@ -1,14 +1,27 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.pages.portal;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import jakarta.inject.Inject;
-
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.ui.test.junit5.EnablePortalUiEnvironment;
 import de.cuioss.portal.ui.test.tests.AbstractPageBeanTest;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @EnablePortalUiEnvironment
 class PortalTemplateBeanTest extends AbstractPageBeanTest<PortalTemplateBean> {

--- a/src/test/java/de/cuioss/portal/reference/portal/ReferenceTemplatesTest.java
+++ b/src/test/java/de/cuioss/portal/reference/portal/ReferenceTemplatesTest.java
@@ -1,16 +1,29 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import jakarta.inject.Inject;
-
-import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.ui.api.templating.PortalTemplateDescriptor;
 import de.cuioss.test.valueobjects.junit5.contracts.ShouldBeNotNull;
 import de.cuioss.tools.io.FileLoaderUtility;
+import jakarta.inject.Inject;
 import lombok.Getter;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableAutoWeld
 class ReferenceTemplatesTest implements ShouldBeNotNull<ReferenceTemplates> {

--- a/src/test/java/de/cuioss/portal/reference/portal/application/ReferenceBundleTest.java
+++ b/src/test/java/de/cuioss/portal/reference/portal/application/ReferenceBundleTest.java
@@ -1,26 +1,39 @@
+/*
+ * Copyright © 2025 CUI-OpenSource-Software (info@cuioss.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.cuioss.portal.reference.portal.application;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.context.SessionScoped;
-import jakarta.inject.Inject;
-
-import org.jboss.weld.junit5.auto.ActivateScopes;
-import org.jboss.weld.junit5.auto.AddBeanClasses;
-import org.jboss.weld.junit5.auto.EnableAutoWeld;
-import org.junit.jupiter.api.Test;
 
 import de.cuioss.portal.common.bundle.PortalResourceBundleBean;
 import de.cuioss.portal.common.bundle.ResourceBundleWrapper;
 import de.cuioss.portal.common.bundle.ResourceBundleWrapperImpl;
 import de.cuioss.portal.ui.test.mocks.PortalLocaleProducerMock;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.inject.Inject;
+import org.jboss.weld.junit5.auto.ActivateScopes;
+import org.jboss.weld.junit5.auto.AddBeanClasses;
+import org.jboss.weld.junit5.auto.EnableAutoWeld;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableAutoWeld
-@AddBeanClasses({ ReferenceBundle.class, PortalResourceBundleBean.class, ResourceBundleWrapperImpl.class,
-        PortalLocaleProducerMock.class })
-@ActivateScopes({ RequestScoped.class, SessionScoped.class })
+@AddBeanClasses({ReferenceBundle.class, PortalResourceBundleBean.class, ResourceBundleWrapperImpl.class,
+    PortalLocaleProducerMock.class})
+@ActivateScopes({RequestScoped.class, SessionScoped.class})
 class ReferenceBundleTest {
 
     @Inject


### PR DESCRIPTION
## Summary
- Update parent POM from `cui-parent-pom:0.8.3` to `cui-java-parent:1.4.4`
- Update dependency versions: `cui-jsf-components` 1.0.0, `cui-portal-core` 1.4.0, Quarkus 3.32.0
- Fix breaking API changes (renamed classes, changed constructors, removed internal APIs)
- Apply pre-commit formatting (license headers, OpenRewrite Java 21 migrations, CUI logging standards)
- Fix javadoc warnings and deprecation warnings
- Replace OpenRewrite search markers with proper `cui-rewrite:disable` suppress directives
- Fix generic exception usage in ConfigDocuBean with `UncheckedIOException`
- Add CLAUDE.md for Claude Code guidance

## Test plan
- [x] `./mvnw clean install -Ppre-commit` passes (45 tests, 0 failures)
- [x] No deprecation or javadoc warnings
- [x] Pre-commit build is idempotent (no marker accumulation)
- [x] No compilation warnings with `-Dmaven.compiler.showDeprecation=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)